### PR TITLE
actions/checkout is now v4.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Setup Perl environment
         uses: shogo82148/actions-setup-perl@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Toolchain
         run: cpanm -q -n --no-man-pages App::cpm
       - name: Install Test2::Harness


### PR DESCRIPTION
this can probably get rid of the following warning about node16

    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.